### PR TITLE
[Feature] improved Endpoint enum for maintainability and scalability

### DIFF
--- a/FetchBook/MODELS/Recipe/RecipeEndpoints.swift
+++ b/FetchBook/MODELS/Recipe/RecipeEndpoints.swift
@@ -9,31 +9,30 @@ import Foundation
 
 // DEBUG PURPOSES ONLY
 
-/// Enum representing the types of recipe endpoints, each with a raw string value.
-/// This enum is also `CaseIterable`, allowing iteration over all cases.
-enum RecipeEndpointTypes: String, CaseIterable { case all, malformed, empty }
-
-/// Enumeration representing different API endpoints for fetching recipes.
-/// Each case is a static constant containing a `RecipeEndpointModel`,
-/// which defines the type of endpoint and the corresponding URL.
-enum RecipeEndpoints: CaseIterable, Hashable {
-    // Endpoint for all recipes.
-    static let all: RecipeEndpointModel = .init(type: .all, urlString: "https://d3jbb8n5wk0qxi.cloudfront.net/recipes.json")
+// Enum representing the types of recipe endpoints, each with a raw string value.
+enum RecipeEndpointTypes: String, CaseIterable {
+    case all = "https://d3jbb8n5wk0qxi.cloudfront.net/recipes.json"
+    case malformed = "https://d3jbb8n5wk0qxi.cloudfront.net/recipes-malformed.json"
+    case empty = "https://d3jbb8n5wk0qxi.cloudfront.net/recipes-empty.json"
     
-    // Endpoint for malformed data.
-    static let malformed: RecipeEndpointModel = .init(type: .malformed, urlString: "https://d3jbb8n5wk0qxi.cloudfront.net/recipes-malformed.json")
-    
-    // Endpoint for empty data.
-    static let empty: RecipeEndpointModel = .init(type: .empty, urlString: "https://d3jbb8n5wk0qxi.cloudfront.net/recipes-empty.json")
-    
-    // An array of all available recipe endpoint models, used for iterating or selection in UI elements.
-    static var allCases: [RecipeEndpointModel] {
-        [all, malformed, empty]
+    // Computed property to return the type as a string.
+    var typeString: String {
+        switch self {
+        case .all: "all"
+        case .malformed: "malformed"
+        case .empty: "empty"
+        }
     }
+    
+    // Computed property to return the corresponding URL string.
+    var urlString: String { self.rawValue }
+    
+    // Computed property to return a RecipeEndpointModel for the type.
+    var endpointModel: RecipeEndpointModel { RecipeEndpointModel(type: self, urlString: self.urlString) }
 }
 
-/// Model representing a recipe API endpoint.
-/// Contains the endpoint type and its corresponding URL.
+// Model representing a recipe API endpoint.
+// Contains the endpoint type and its corresponding URL.
 struct RecipeEndpointModel: Hashable {
     let type: RecipeEndpointTypes
     let urlString: String

--- a/FetchBook/VIEWMODELS/Recipe/RecipeViewModel.swift
+++ b/FetchBook/VIEWMODELS/Recipe/RecipeViewModel.swift
@@ -42,7 +42,7 @@ final class RecipeViewModel: ObservableObject {
     
     /// The currently selected API endpoint for data retrieval.
     /// debug purposes only.
-    @Published var selectedEndpoint: RecipeEndpointModel = RecipeEndpoints.all
+    @Published var selectedEndpoint: RecipeEndpointModel = RecipeEndpointTypes.all.endpointModel
     
     /// The current status of the data being processed, and fetched.
     @Published var currentDataStatus: RecipeDataStatusTypes = .fetching

--- a/FetchBook/VIEWS/Debug/DebugView.swift
+++ b/FetchBook/VIEWS/Debug/DebugView.swift
@@ -39,9 +39,9 @@ extension DebugView {
     private var endpoint: some View {
         Section {
             Picker("Recipe Endpoints Picker", selection: $recipeVM.selectedEndpoint) {
-                ForEach(RecipeEndpoints.allCases, id: \.self) {
-                    Text($0.type.rawValue.capitalized)
-                        .tag($0)
+                ForEach(RecipeEndpointTypes.allCases, id: \.self) {
+                    Text($0.typeString.capitalized)
+                        .tag($0.endpointModel)
                 }
             }
             .pickerStyle(.segmented)


### PR DESCRIPTION
**Response from Fetch**  
> Your use of enums for endpoints was inefficient. The endpoint can just have its own computed var that represents its endpoint config, rather than having 2 different enums for type and static configurations.

**What's Changed**

1. **Maintainability**  

- **Single Source of Truth**: Each endpoint and its associated URL are defined in one place, reducing duplication and making updates easier.
- **Readability**: The clear structure of enums and computed properties makes the code easier to understand and modify.
- **Type Safety**: Using enums ensures that you only deal with predefined cases, reducing the risk of errors.

1. **Scalability**  

- **Adding New Endpoints**: Simply add a new case to the RecipeEndpointTypes enum without touching other parts of the code.
- **Reuse and Extensibility**: The RecipeEndpointModel struct can easily accommodate additional properties or methods if networking needs expand.
- **Centralized Changes**: Any changes to the URL format or additional parameters can be managed in one place, propagating throughout the app without redundant code.
