### PR TITLE
[Clean] remove complexity from the massive viewmodel

### DIFF
--- a/FetchBook/VIEWMODELS/Recipe/Helpers/RecipeDataManager.swift
+++ b/FetchBook/VIEWMODELS/Recipe/Helpers/RecipeDataManager.swift
@@ -1,0 +1,50 @@
+//
+//  RecipeDataManager.swift
+//  FetchBook
+//
+//  Created by Mr. Kavinda Dilshan on 2024-10-20.
+//
+
+import Foundation
+
+actor RecipeDataManager {
+    // MARK: - PROPERTIES
+    private let recipeVM: RecipeViewModel
+    private let sortingManager: RecipeSortingManager
+    private let recipeService: RecipeDataFetching
+    
+    // MARK: - INITIALIZER
+    init(recipeVM: RecipeViewModel, sortingManager: RecipeSortingManager, recipeService: RecipeDataFetching) {
+        self.recipeVM = recipeVM
+        self.sortingManager = sortingManager
+        self.recipeService = recipeService
+    }
+    
+    // MARK: - FUNCTIONS
+    
+    // MARK: - fetchRecipeData
+    /// Fetches recipe data from the specified endpoint and updates the `recipesArray` and `mutableRecipesArray`.
+    ///
+    /// - The function sets the `currentDataStatus` to `.fetching` while waiting for the data.
+    /// - Once the data is fetched, it updates the `recipesArray` and `mutableRecipesArray` with the fetched recipes.
+    /// - If no recipes are returned, the `currentDataStatus` is set to `.emptyData`, otherwise it is set to `.none`.
+    /// - If an error occurs during fetching, the `currentDataStatus` is updated to `.malformed`, and the error is thrown.
+    ///
+    /// - Parameter endpoint: The endpoint from which to fetch the recipe data.
+    /// - Throws: An error if fetching data from the `RecipeService` fails.
+    func fetchRecipeData(endpoint: RecipeEndpointModel) async throws {
+        await recipeVM.updateDataStatus(.fetching)
+        
+        do {
+            let recipesResponse = try await recipeService.fetchRecipeData(from: endpoint)
+            let recipes: [RecipeModel] = recipesResponse.recipes
+            
+            await recipeVM.updateDataStatus(recipes.isEmpty ? .emptyData : .none)
+            await recipeVM.updateRecipesArray(recipes) // Store fetched recipes in recipesArray.
+            await sortingManager.assignSortedRecipesToMutableRecipesArray() // Initialize mutableRecipesArray with the fetched and sorted recipes.
+        } catch {
+            await recipeVM.updateDataStatus(.malformed)
+            throw error
+        }
+    }
+}

--- a/FetchBook/VIEWMODELS/Recipe/Helpers/RecipeFilteringManager.swift
+++ b/FetchBook/VIEWMODELS/Recipe/Helpers/RecipeFilteringManager.swift
@@ -5,8 +5,139 @@
 //  Created by Mr. Kavinda Dilshan on 2024-10-20.
 //
 
-import Foundation
+import SwiftUI
 
 actor RecipeFilteringManager {
+    // MARK: - PROPERTIES
+    private let recipeVM: RecipeViewModel
+    private let sortingManager: RecipeSortingManager
     
+    //  MARK: - INITIALIZER
+    init(recipeVM: RecipeViewModel, sortingManager: RecipeSortingManager) {
+        self.recipeVM = recipeVM
+        self.sortingManager = sortingManager
+    }
+    
+    // MARK: - FUNCTIONS
+    
+    // MARK: - createDebouncedTextStream
+    /// Creates a debounced async stream from the `recipeSearchText` publisher.
+    ///
+    /// This function converts the `recipeSearchText` Combine publisher into an `AsyncStream` so that it can be consumed with async/await. It yields new search text whenever it is updated.
+    ///
+    /// - Returns: An `AsyncStream<String>` that emits the latest value of `recipeSearchText` each time it is updated.
+    @MainActor
+    private func createDebouncedTextStream() async -> AsyncStream<String> {
+        AsyncStream { continuation in
+            // Subscribe to the `recipeSearchText` publisher
+            let subscription = recipeVM.$recipeSearchText
+                .dropFirst()
+                .sink { text in
+                    continuation.yield(text) // Yield the new text value to the async stream
+                }
+            
+            // Cancel the subscription when the async stream is terminated
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+        }
+    }
+    
+    // MARK: - handleDebouncedSearchText
+    /// Handles the debounced search text logic, performing a search or resetting recipes depending on the text.
+    ///
+    /// This function checks if the text has changed long enough to trigger a search or reset. If the text is empty, it resets the recipes with the current sorting option. Otherwise, it calls the filtering method.
+    ///
+    /// - Parameters:
+    ///   - text: The latest text from the search field.
+    ///   - lastSearchTime: A reference to the last time the search was triggered. This will be updated based on the debounce logic.
+    ///   - debounceDelay: The time delay (in seconds) between search queries, used to debounce rapid text changes.
+    private func handleDebouncedSearchText(_ text: String, lastSearchTime: inout Date, debounceDelay: TimeInterval) async {
+        let timeElapsed = Date().timeIntervalSince(lastSearchTime)
+        
+        // If enough time has passed since the last search, perform the necessary action
+        if timeElapsed > debounceDelay {
+            lastSearchTime = Date() // Update the last search time
+            
+            // If the search text is empty, reset data and update recipes
+            if text.isEmpty {
+                await resetRecipes()
+            } else {
+                // Otherwise, perform the filtering logic asynchronously
+                await filterSearchResult(text: text)
+            }
+        } else {
+            // If debounce delay hasn't passed, sleep for the remaining time before checking again
+            let sleepTime = debounceDelay - timeElapsed
+            try? await Task.sleep(nanoseconds: UInt64(sleepTime * 1_000_000_000)) // Sleep for the remaining time in nanoseconds
+        }
+    }
+    
+    // MARK: - recipeSearchTextSubscriber
+    /// Main function to subscribe to recipe search text updates and handle them asynchronously with debounce.
+    ///
+    /// This function listens for updates to `recipeSearchText`, applies debouncing logic, and then triggers either a reset of recipes or filtering of search results based on the text. The logic ensures that searches are only triggered after the user has stopped typing for a defined period of time (debounce).
+    func recipeSearchTextSubscriber() async {
+        Task {
+            var lastSearchTime = Date()
+            let debounceDelay: TimeInterval = 0.1 // Define the debounce delay (0.1 seconds)
+            
+            // Create the debounced text stream to consume the latest recipe search text
+            let debouncedTextStream = await createDebouncedTextStream()
+            
+            // Iterate over the debounced text stream
+            for await text in debouncedTextStream {
+                // Handle the debounced search text asynchronously
+                await handleDebouncedSearchText(text, lastSearchTime: &lastSearchTime, debounceDelay: debounceDelay)
+            }
+        }
+    }
+    
+    // MARK: - resetRecipes
+    /// Resets the recipes and sets the current data status to `.none` when the search text is empty.
+    ///
+    /// This function is called when the search text is cleared, to reset the data state and update the recipe list according to the current sorting option.
+    ///
+    /// This operation runs on the main actor to update the UI-related state.
+    private func resetRecipes() async {
+        await recipeVM.updateDataStatus(.none)
+        await sortingManager.assignSortedRecipesToMutableRecipesArray() // Reset recipes with the current sorting
+    }
+    
+    // MARK: - filterSearchResult
+    /// Filters the `mutableRecipesArray` based on the provided search text.
+    ///
+    /// - Converts the search text to lowercase to enable case-insensitive matching.
+    /// - Filters the recipes by checking if the recipe's name or cuisine contains the search text.
+    /// - Updates the `mutableRecipesArray` with the recipes that match the search criteria.
+    /// - If the search text is empty, it resets `mutableRecipesArray` to the full `recipesArray`.
+    /// - If no recipes match the search criteria, updates the `mutableRecipesArray` with an empty array.
+    /// - Animates the update to `mutableRecipesArray` if matching recipes are found.
+    /// - Updates the `currentDataStatus` to `.emptyResult` if no matches are found, or to `.none` otherwise.
+    ///
+    /// - Parameter text: The search text entered by the user to filter the recipe list.
+    @MainActor
+    private func filterSearchResult(text: String) async {
+        guard !text.isEmpty else {
+            await sortingManager.assignSortedRecipesToMutableRecipesArray()
+            return
+        }
+        
+        let lowercasedText: String = text.lowercased()
+        let sortedRecipesArray: [RecipeModel] = await sortingManager.sortRecipes(option: recipeVM.selectedSortOption)
+        let filteredRecipesArray: [RecipeModel] = sortedRecipesArray.filter({
+            $0.name.lowercased().contains(lowercasedText) ||
+            $0.cuisine.lowercased().contains(lowercasedText)
+        })
+        
+        if filteredRecipesArray.isEmpty {
+            recipeVM.updateMutableRecipesArray(filteredRecipesArray)
+        } else {
+            withAnimation {
+                recipeVM.updateMutableRecipesArray(filteredRecipesArray)
+            }
+        }
+        
+        recipeVM.updateDataStatus(recipeVM.mutableRecipesArray.isEmpty ? .emptyResult : .none)
+    }
 }

--- a/FetchBook/VIEWMODELS/Recipe/Helpers/RecipeSortingManager.swift
+++ b/FetchBook/VIEWMODELS/Recipe/Helpers/RecipeSortingManager.swift
@@ -8,5 +8,88 @@
 import Foundation
 
 actor RecipeSortingManager {
+    // MARK: - PROPERTIES
+    private let recipeVM: RecipeViewModel
     
+    // MARK: - INITIALIZER
+    init(recipeVM: RecipeViewModel) {
+        self.recipeVM = recipeVM
+    }
+    
+    //MARK: - FUNCTIONS
+    
+    // MARK: - sortRecipes
+    /// Sorts the `recipesArray` based on the specified sorting option.
+    ///
+    /// - Parameter option: The sorting option to apply. Can be one of the following:
+    ///   - `.ascending`: Sorts the array in ascending order (A-Z) based on the `name` property of `RecipeModel`.
+    ///   - `.descending`: Sorts the array in descending order (Z-A) based on the `name` property of `RecipeModel`.
+    ///   - `.none`: Returns the array without any sorting (keeps the original order).
+    ///
+    /// - Returns: An array of `RecipeModel` sorted according to the specified option. If `.ascending` or `.descending` is selected, the recipes are sorted by their `name`. If `.none` is selected, the original order of `recipesArray` is retained.
+    func sortRecipes(option: RecipeSortOptions) async -> [RecipeModel] {
+        switch option {
+        case .ascending: await recipeVM.recipesArray.sorted(by: { $0.name < $1.name }) // Sort A-Z.
+        case .descending: await recipeVM.recipesArray.sorted(by: { $0.name > $1.name }) // Sort Z-A.
+        case .none: await recipeVM.recipesArray // Return unsorted array.
+        }
+    }
+    
+    // MARK: - assignSortedRecipesToMutableRecipesArray
+    /// Assigns sorted recipes to the `mutableRecipesArray`.
+    ///
+    /// This function sorts the recipes based on the specified sort option and assigns the sorted result to the `mutableRecipesArray`.
+    /// If no sort option is provided, it defaults to the `selectedSortOption`.
+    ///
+    /// - Parameter option: An optional `RecipeSortOptions` value that determines the sorting criteria. If `nil`, the currently selected sort option will be used.
+    /// - The function calls `sortRecipes(option:)` to sort the recipes and assigns the result to `mutableRecipesArray`.
+    @MainActor
+    func assignSortedRecipesToMutableRecipesArray(_ option: RecipeSortOptions? = nil) async {
+        // Sort recipes using the provided option, or the default selectedSortOption if none is provided.
+        await recipeVM.updateMutableRecipesArray(sortRecipes(option: option ?? recipeVM.selectedSortOption))
+    }
+    
+    // MARK: - sortOptionSubscriber
+    /// Sets up a subscriber to observe changes in the selected sort option
+    /// and updates the `mutableRecipesArray` accordingly.
+    ///
+    /// - This function listens for changes to the `selectedSortOption` property, which determines how the recipes should be sorted.
+    /// - When the sort option is updated (e.g., A-Z, Z-A, or none), the function calls `sortRecipes(option:)` to sort the array based on the selected option.
+    /// - Updates the `mutableRecipesArray` with the sorted results.
+    /// - Stores the subscription in `cancelables` to ensure proper memory management and prevent memory leaks.
+    func sortOptionSubscriber() async {
+        // Convert Combine publisher to async sequence
+        // The for-await loop listens for new values from the publisher and processes them as they arrive.
+        for await option in await sortOptionAsyncPublisher(for: recipeVM.$selectedSortOption) {
+            // Ensure the UI updates are done on the main thread
+            // Since `assignSortedRecipesToMutableRecipesArray(option:)` might modify the UI,
+            // we use MainActor.run to guarantee it runs on the main thread.
+            await assignSortedRecipesToMutableRecipesArray(option)
+        }
+    }
+    
+    // MARK: - sortOptionAsyncPublisher
+    /// Converts a Combine publisher into an async sequence to be used with async-await syntax.
+    ///
+    /// - Takes a `Published<RecipeSortOptions>.Publisher` (i.e., a Combine publisher of `RecipeSortOptions`).
+    /// - Yields values from the publisher as they arrive.
+    /// - Properly handles cancellation when the async sequence terminates, ensuring no memory leaks.
+    private func sortOptionAsyncPublisher(for publisher: Published<RecipeSortOptions>.Publisher) async -> AsyncStream<RecipeSortOptions> {
+        AsyncStream { continuation in
+            // Create a cancellable to handle the subscription to the publisher.
+            let cancellable = publisher
+                .dropFirst()
+                .sink { option in
+                    // When a new value is received, yield it into the async sequence.
+                    continuation.yield(option)
+                }
+            
+            // Proper cancellation when the stream terminates
+            // This ensures that when the async sequence is cancelled, the Combine subscription is also cancelled,
+            // preventing memory leaks and unnecessary background work.
+            continuation.onTermination = { _ in
+                cancellable.cancel()
+            }
+        }
+    }
 }

--- a/FetchBook/VIEWMODELS/Recipe/RecipeViewModel.swift
+++ b/FetchBook/VIEWMODELS/Recipe/RecipeViewModel.swift
@@ -13,8 +13,16 @@ import SwiftUI
 final class RecipeViewModel: ObservableObject {
     
     // MARK: - PROPERTIES
+    
     /// A service for fetching recipe data, adhering to the `RecipeDataFetching` protocol.
-    let recipeService: RecipeDataFetching
+    private let recipeService: RecipeDataFetching
+    private lazy var sortingManager: RecipeSortingManager = .init(recipeVM: self)
+    private lazy var filteringManager: RecipeFilteringManager = .init(recipeVM: self, sortingManager: sortingManager)
+    private lazy var dataManager: RecipeDataManager = .init(
+        recipeVM: self,
+        sortingManager: sortingManager,
+        recipeService: recipeService
+    )
     
     // MARK: - INITIALIZER
     /// Initializes a new instance of `RecipeViewModel` with the provided recipe service.
@@ -25,8 +33,11 @@ final class RecipeViewModel: ObservableObject {
     /// - Parameter recipeService: A service conforming to `RecipeDataFetching` for fetching recipe data.
     init(recipeService: RecipeDataFetching) {
         self.recipeService = recipeService
-        sortOptionSubscriber() // Subscribe to changes in the selected sorting option.
-        recipeSearchTextSubscriber()
+        
+        Task {
+            await self.sortingManager.sortOptionSubscriber()
+            await self.filteringManager.recipeSearchTextSubscriber()
+        }
     }
     
     // MARK: - PRIVATE PROPERTIES
@@ -38,7 +49,7 @@ final class RecipeViewModel: ObservableObject {
     @Published private(set) var mutableRecipesArray: [RecipeModel] = []
     
     /// The current status of the data being processed, and fetched.
-    @Published private(set) var currentDataStatus: RecipeDataStatusTypes = .none
+    @Published private(set) var currentDataStatus: RecipeDataStatusTypes = .fetching
     
     /// A string that holds the user's recipe search input.
     @Published private(set) var recipeSearchText: String = ""
@@ -64,225 +75,24 @@ final class RecipeViewModel: ObservableObject {
     
     // MARK: - FUNCTIONS
     
+    // MARK: - updateDataStatus
+    /// Public method to update the current data status.
+    func updateDataStatus(_ newStatus: RecipeDataStatusTypes) {
+        self.currentDataStatus = newStatus
+    }
+    
+    // MARK: - updateMutableRecipesArray
+    func updateMutableRecipesArray(_ newArray: [RecipeModel]) {
+        self.mutableRecipesArray = newArray
+    }
+    
+    // MARK: - updateRecipesArray
+    func updateRecipesArray(_ newArray: [RecipeModel]) {
+        self.recipesArray = newArray
+    }
+    
     // MARK: - fetchRecipeData
-    /// Fetches recipe data from the specified endpoint and updates the `recipesArray` and `mutableRecipesArray`.
-    ///
-    /// - The function sets the `currentDataStatus` to `.fetching` while waiting for the data.
-    /// - Once the data is fetched, it updates the `recipesArray` and `mutableRecipesArray` with the fetched recipes.
-    /// - If no recipes are returned, the `currentDataStatus` is set to `.emptyData`, otherwise it is set to `.none`.
-    /// - If an error occurs during fetching, the `currentDataStatus` is updated to `.malformed`, and the error is thrown.
-    ///
-    /// - Parameter endpoint: The endpoint from which to fetch the recipe data.
-    /// - Throws: An error if fetching data from the `RecipeService` fails.
     func fetchRecipeData(endpoint: RecipeEndpointModel) async throws {
-        await MainActor.run { currentDataStatus = .fetching }
-        
-        do {
-            let recipesResponse = try await recipeService.fetchRecipeData(from: endpoint)
-            let recipes: [RecipeModel] = recipesResponse.recipes
-            
-            await MainActor.run {
-                currentDataStatus = recipes.isEmpty ? .emptyData : .none
-                recipesArray = recipes // Store fetched recipes in recipesArray.
-                assignSortedRecipesToMutableRecipesArray() // Initialize mutableRecipesArray with the fetched and sorted recipes.
-            }
-        } catch {
-            await MainActor.run { currentDataStatus = .malformed }
-            throw error
-        }
-    }
-    
-    // MARK: - assignSortedRecipesToMutableRecipesArray
-    /// Assigns sorted recipes to the `mutableRecipesArray`.
-    ///
-    /// This function sorts the recipes based on the specified sort option and assigns the sorted result to the `mutableRecipesArray`.
-    /// If no sort option is provided, it defaults to the `selectedSortOption`.
-    ///
-    /// - Parameter option: An optional `RecipeSortOptions` value that determines the sorting criteria. If `nil`, the currently selected sort option will be used.
-    /// - The function calls `sortRecipes(option:)` to sort the recipes and assigns the result to `mutableRecipesArray`.
-    private func assignSortedRecipesToMutableRecipesArray(_ option: RecipeSortOptions? = nil) {
-        // Sort recipes using the provided option, or the default selectedSortOption if none is provided.
-        mutableRecipesArray = sortRecipes(option: option ?? selectedSortOption)
-    }
-    
-    // MARK: - sortRecipes
-    /// Sorts the `recipesArray` based on the specified sorting option.
-    ///
-    /// - Parameter option: The sorting option to apply. Can be one of the following:
-    ///   - `.ascending`: Sorts the array in ascending order (A-Z) based on the `name` property of `RecipeModel`.
-    ///   - `.descending`: Sorts the array in descending order (Z-A) based on the `name` property of `RecipeModel`.
-    ///   - `.none`: Returns the array without any sorting (keeps the original order).
-    ///
-    /// - Returns: An array of `RecipeModel` sorted according to the specified option. If `.ascending` or `.descending` is selected, the recipes are sorted by their `name`. If `.none` is selected, the original order of `recipesArray` is retained.
-    func sortRecipes(option: RecipeSortOptions) -> [RecipeModel] {
-        switch option {
-        case .ascending: return recipesArray.sorted(by: { $0.name < $1.name }) // Sort A-Z.
-        case .descending: return recipesArray.sorted(by: { $0.name > $1.name }) // Sort Z-A.
-        case .none: return recipesArray // Return unsorted array.
-        }
-    }
-    
-    // MARK: - sortOptionSubscriber
-    /// Sets up a subscriber to observe changes in the selected sort option
-    /// and updates the `mutableRecipesArray` accordingly.
-    ///
-    /// - This function listens for changes to the `selectedSortOption` property, which determines how the recipes should be sorted.
-    /// - When the sort option is updated (e.g., A-Z, Z-A, or none), the function calls `sortRecipes(option:)` to sort the array based on the selected option.
-    /// - Updates the `mutableRecipesArray` with the sorted results.
-    /// - Stores the subscription in `cancelables` to ensure proper memory management and prevent memory leaks.
-    private func sortOptionSubscriber() {
-        Task {
-            // Convert Combine publisher to async sequence
-            // The for-await loop listens for new values from the publisher and processes them as they arrive.
-            for await option in sortOptionAsyncPublisher(for: $selectedSortOption) {
-                // Ensure the UI updates are done on the main thread
-                // Since `assignSortedRecipesToMutableRecipesArray(option:)` might modify the UI,
-                // we use MainActor.run to guarantee it runs on the main thread.
-                await MainActor.run {
-                    assignSortedRecipesToMutableRecipesArray(option)
-                }
-            }
-        }
-    }
-    
-    // MARK: - sortOptionAsyncPublisher
-    /// Converts a Combine publisher into an async sequence to be used with async-await syntax.
-    ///
-    /// - Takes a `Published<RecipeSortOptions>.Publisher` (i.e., a Combine publisher of `RecipeSortOptions`).
-    /// - Yields values from the publisher as they arrive.
-    /// - Properly handles cancellation when the async sequence terminates, ensuring no memory leaks.
-    private func sortOptionAsyncPublisher(for publisher: Published<RecipeSortOptions>.Publisher) -> AsyncStream<RecipeSortOptions> {
-        AsyncStream { continuation in
-            // Create a cancellable to handle the subscription to the publisher.
-            let cancellable = publisher.sink { option in
-                // When a new value is received, yield it into the async sequence.
-                continuation.yield(option)
-            }
-            
-            // Proper cancellation when the stream terminates
-            // This ensures that when the async sequence is cancelled, the Combine subscription is also cancelled,
-            // preventing memory leaks and unnecessary background work.
-            continuation.onTermination = { _ in
-                cancellable.cancel()
-            }
-        }
-    }
-    
-    // MARK: - createDebouncedTextStream
-    /// Creates a debounced async stream from the `recipeSearchText` publisher.
-    ///
-    /// This function converts the `recipeSearchText` Combine publisher into an `AsyncStream` so that it can be consumed with async/await. It yields new search text whenever it is updated.
-    ///
-    /// - Returns: An `AsyncStream<String>` that emits the latest value of `recipeSearchText` each time it is updated.
-    private func createDebouncedTextStream() -> AsyncStream<String> {
-        return AsyncStream { continuation in
-            // Subscribe to the `recipeSearchText` publisher
-            let subscription = $recipeSearchText
-                .sink { text in
-                    continuation.yield(text) // Yield the new text value to the async stream
-                }
-            
-            // Cancel the subscription when the async stream is terminated
-            continuation.onTermination = { _ in
-                subscription.cancel()
-            }
-        }
-    }
-    
-    // MARK: - handleDebouncedSearchText
-    /// Handles the debounced search text logic, performing a search or resetting recipes depending on the text.
-    ///
-    /// This function checks if the text has changed long enough to trigger a search or reset. If the text is empty, it resets the recipes with the current sorting option. Otherwise, it calls the filtering method.
-    ///
-    /// - Parameters:
-    ///   - text: The latest text from the search field.
-    ///   - lastSearchTime: A reference to the last time the search was triggered. This will be updated based on the debounce logic.
-    ///   - debounceDelay: The time delay (in seconds) between search queries, used to debounce rapid text changes.
-    private func handleDebouncedSearchText(_ text: String, lastSearchTime: inout Date, debounceDelay: TimeInterval) async {
-        let timeElapsed = Date().timeIntervalSince(lastSearchTime)
-        
-        // If enough time has passed since the last search, perform the necessary action
-        if timeElapsed > debounceDelay {
-            lastSearchTime = Date() // Update the last search time
-            
-            // If the search text is empty, reset data and update recipes
-            if text.isEmpty {
-                resetRecipes()
-            } else {
-                // Otherwise, perform the filtering logic asynchronously
-                filterSearchResult(text: text)
-            }
-        } else {
-            // If debounce delay hasn't passed, sleep for the remaining time before checking again
-            let sleepTime = debounceDelay - timeElapsed
-            try? await Task.sleep(nanoseconds: UInt64(sleepTime * 1_000_000_000)) // Sleep for the remaining time in nanoseconds
-        }
-    }
-    
-    // MARK: - resetRecipes
-    /// Resets the recipes and sets the current data status to `.none` when the search text is empty.
-    ///
-    /// This function is called when the search text is cleared, to reset the data state and update the recipe list according to the current sorting option.
-    ///
-    /// This operation runs on the main actor to update the UI-related state.
-    private func resetRecipes() {
-        currentDataStatus = .none
-        assignSortedRecipesToMutableRecipesArray() // Reset recipes with the current sorting
-    }
-    
-    // MARK: - recipeSearchTextSubscriber
-    /// Main function to subscribe to recipe search text updates and handle them asynchronously with debounce.
-    ///
-    /// This function listens for updates to `recipeSearchText`, applies debouncing logic, and then triggers either a reset of recipes or filtering of search results based on the text. The logic ensures that searches are only triggered after the user has stopped typing for a defined period of time (debounce).
-    private func recipeSearchTextSubscriber() {
-        Task {
-            var lastSearchTime = Date()
-            let debounceDelay: TimeInterval = 0.1 // Define the debounce delay (0.1 seconds)
-            
-            // Create the debounced text stream to consume the latest recipe search text
-            let debouncedTextStream = createDebouncedTextStream()
-            
-            // Iterate over the debounced text stream
-            for await text in debouncedTextStream {
-                // Handle the debounced search text asynchronously
-                await handleDebouncedSearchText(text, lastSearchTime: &lastSearchTime, debounceDelay: debounceDelay)
-            }
-        }
-    }
-    
-    // MARK: - filterSearchResult
-    /// Filters the `mutableRecipesArray` based on the provided search text.
-    ///
-    /// - Converts the search text to lowercase to enable case-insensitive matching.
-    /// - Filters the recipes by checking if the recipe's name or cuisine contains the search text.
-    /// - Updates the `mutableRecipesArray` with the recipes that match the search criteria.
-    /// - If the search text is empty, it resets `mutableRecipesArray` to the full `recipesArray`.
-    /// - If no recipes match the search criteria, updates the `mutableRecipesArray` with an empty array.
-    /// - Animates the update to `mutableRecipesArray` if matching recipes are found.
-    /// - Updates the `currentDataStatus` to `.emptyResult` if no matches are found, or to `.none` otherwise.
-    ///
-    /// - Parameter text: The search text entered by the user to filter the recipe list.
-    func filterSearchResult(text: String) {
-        guard !text.isEmpty else {
-            assignSortedRecipesToMutableRecipesArray()
-            return
-        }
-        
-        let lowercasedText: String = text.lowercased()
-        let sortedRecipesArray: [RecipeModel] = sortRecipes(option: selectedSortOption)
-        let filteredRecipesArray: [RecipeModel] = sortedRecipesArray.filter({
-            $0.name.lowercased().contains(lowercasedText) ||
-            $0.cuisine.lowercased().contains(lowercasedText)
-        })
-        
-        if filteredRecipesArray.isEmpty {
-            mutableRecipesArray = filteredRecipesArray
-        } else {
-            withAnimation {
-                mutableRecipesArray = filteredRecipesArray
-            }
-        }
-        
-        currentDataStatus = mutableRecipesArray.isEmpty ? .emptyResult : .none
+        try await dataManager.fetchRecipeData(endpoint: endpoint)
     }
 }

--- a/FetchBook/VIEWS/ContentView.swift
+++ b/FetchBook/VIEWS/ContentView.swift
@@ -34,6 +34,10 @@ struct ContentView: View {
 }
 
 // MARK: - PREVIEWS
-#Preview("ContentView") {
+#Preview("ContentView - MockRecipeAPIService") {
     ContentView(recipeService: MockRecipeAPIService())
+}
+
+#Preview("ContentView - RecipeAPIService") {
+    ContentView(recipeService: RecipeAPIService())
 }


### PR DESCRIPTION
**Fetch Response:**
> How might we be able to remove complexity from the massive ViewModel?

**What's changed?**

1. **Separation of Concerns:**
- Divide Responsibilities: Ensure each class or function has a single responsibility. Split the ViewModel into smaller, more focused components.
- Helpers and Services: Delegate specific tasks to helper classes or services. For instance, network calls can be handled by a data service, and business logic can be managed by specialized managers.

2. **Actors for Concurrency:**
- Swift Concurrency: Utilize actors to manage concurrency, ensuring thread-safe operations and reducing complexity in async code.
- Async/Await: Replace GCD with async/await for cleaner and more readable asynchronous code.

3. **Modularization:**
- Feature-Specific Modules: Break down the ViewModel into feature-specific modules. Each module should handle a specific part of the functionality, such as sorting, filtering, and data fetching.
- Reusable Components: Create reusable components for common tasks, reducing code duplication and enhancing maintainability.

